### PR TITLE
Enforce format in the query string, and always return application/json as the content-type

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,8 +43,7 @@ def proxy_app(
     proxied_request_headers = ['range', ]
     proxied_response_codes = [200, 206, 404, ]
     proxied_response_headers = [
-        'accept-ranges', 'content-length', 'content-type', 'date', 'etag', 'last-modified',
-        'content-range',
+        'accept-ranges', 'content-length', 'date', 'etag', 'last-modified', 'content-range',
     ]
 
     def start():
@@ -93,10 +92,12 @@ def proxy_app(
         response = http.request(method, f'{url}?{encoded_params}', headers=dict(
             request_headers), body=body, preload_content=False)
 
-        response_headers = tuple((
+        response_headers_no_content_type = tuple((
             (key, response.headers[key])
             for key in proxied_response_headers if key in response.headers
         ))
+        response_headers = response_headers_no_content_type + \
+            (('content-type', 'application/json'),)
         allow_proxy = response.status in proxied_response_codes
 
         logger.debug('Response: %s', response)

--- a/app.py
+++ b/app.py
@@ -56,6 +56,14 @@ def proxy_app(
     def proxy(dataset_id, version):
         logger.debug('Attempt to proxy: %s %s %s', request, dataset_id, version)
 
+        try:
+            _format = request.args['format']
+        except KeyError:
+            return 'The query string must have a "format" term', 400
+
+        if _format != 'json':
+            return 'The query string "format" term must equal "json"', 400
+
         url = f'{endpoint_url}{dataset_id}/v{version}/data.json'
         parsed_url = urllib.parse.urlsplit(url)
         method, body, params, parse_response = \

--- a/test.py
+++ b/test.py
@@ -82,6 +82,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version)) as response:
             self.assertEqual(response.content, content)
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -157,6 +158,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), stream=True) as response:
 
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
             process.terminate()
 
             for chunk in response.iter_content(chunk_size=16384):
@@ -181,6 +183,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), stream=True) as response:
 
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
             process.terminate()
             time.sleep(0.1)
             process.terminate()
@@ -204,6 +207,7 @@ class TestS3Proxy(unittest.TestCase):
                 requests.Session() as session, \
                 session.get(version_public_url(dataset_id, version), stream=True) as response:
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
 
             process.terminate()
 
@@ -268,6 +272,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), headers=headers) as response:
             self.assertEqual(response.content, content)
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
 
     @with_application(8080)
     def test_range_request_after_start(self, _):
@@ -282,6 +287,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), headers=headers) as response:
             self.assertEqual(response.content, content[1:])
             self.assertEqual(response.headers['content-length'], str(len(content) - 1))
+            self.assertEqual(response.headers['content-type'], 'application/json')
 
     @with_application(8080, aws_access_key_id='not-exist')
     def test_bad_aws_credentials(self, _):
@@ -322,6 +328,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version)) as response:
             self.assertEqual(response.content, content)
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -343,6 +350,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version)) as response:
             self.assertEqual(response.content, content)
             self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -374,6 +382,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), params=params) as response:
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, expected_content)
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -428,6 +437,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), params=params) as response:
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, expected_content)
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -455,6 +465,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), params=params) as response:
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, expected_content)
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -482,6 +493,7 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(version_public_url(dataset_id, version), params=params) as response:
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, expected_content)
+            self.assertEqual(response.headers['content-type'], 'application/json')
             self.assertEqual(len(response.history), 0)
 
 


### PR DESCRIPTION
Requiring this to make it extremely explicit what the format will be: we will be supporting JSON and CSV.

Potentially down the line we could have a default, but we can add a default in a way that would likely be backward-compatible. We won't be able to remove it.