### PR TITLE
Correct code coverage concurrency settings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
 parallel = True
 branch = True
-concurrency = multiprocessing
+concurrency =
+	multiprocessing
+	gevent


### PR DESCRIPTION
Some lines are being reported as not covered, when they must have been (e.g. a function declaration line, when the lines inside the function have been covered).