### PR TITLE
Remove dead code / unnecessary check for no bytes

### DIFF
--- a/app_aws.py
+++ b/app_aws.py
@@ -126,10 +126,7 @@ def aws_select_parse_result(input_iterable, output_chunk_size):
                 chunk = chunk if offset else b''
 
         def _read_single_chunk(amt):
-            raw = b''.join(chunk for chunk in _read_multiple_chunks(amt))
-            if raw:
-                return raw
-            raise NoMoreBytes()
+            return b''.join(chunk for chunk in _read_multiple_chunks(amt))
 
         return _read_multiple_chunks, _read_single_chunk
 


### PR DESCRIPTION
The function `_read_multiple_chunks` will already raise NoMoreBytes if there aren't enough bytes, so no need to check if it returned anything