### PR TITLE
More correct query parameter name

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,10 +91,10 @@ def proxy_app(
         method, body, params, parse_response = \
             (
                 'POST',
-                aws_select_post_body(request.args['query_sql']),
+                aws_select_post_body(request.args['query-s3-select']),
                 (('select', ''), ('select-type', '2')),
                 aws_select_parse_result,
-            ) if 'query_sql' in request.args else \
+            ) if 'query-s3-select' in request.args else \
             (
                 'GET',
                 b'',

--- a/test.py
+++ b/test.py
@@ -368,7 +368,7 @@ class TestS3Proxy(unittest.TestCase):
         put_version_data(dataset_id, version, content)
 
         params = {
-            'query_sql': 'SELECT * FROM S3Object[*].topLevel[*]'
+            'query-s3-select': 'SELECT * FROM S3Object[*].topLevel[*]'
         }
         expected_content = json.dumps({
             'rows': (
@@ -398,7 +398,7 @@ class TestS3Proxy(unittest.TestCase):
         put_version_data(dataset_id, version, content)
 
         params = {
-            'query_sql': 'SELECT * FROM S3Object[*].topLevel[*]'
+            'query-s3-select': 'SELECT * FROM S3Object[*].topLevel[*]'
         }
         expected_content = json.dumps({
             'rows': (
@@ -425,7 +425,7 @@ class TestS3Proxy(unittest.TestCase):
         put_version_data(dataset_id, version, content)
 
         params = {
-            'query_sql': 'SELECT * FROM S3Object[*].topLevel[*]'
+            'query-s3-select': 'SELECT * FROM S3Object[*].topLevel[*]'
         }
         expected_content = json.dumps({
             'rows': (
@@ -455,7 +455,9 @@ class TestS3Proxy(unittest.TestCase):
         put_version_data(dataset_id, version, content)
 
         params = {
-            'query_sql': "SELECT * FROM S3Object[*].topLevel[*] AS t WHERE t.a = '>&' OR t.a='🍰'"
+            'query-s3-select':
+                'SELECT * FROM S3Object[*].topLevel[*] AS t '
+                + "WHERE t.a = '>&' OR t.a='🍰'"
         }
         expected_content = json.dumps({
             'rows': [{'a': '>&', 'd': 'e'}] * 100000 + [{'a': '🍰', 'd': 'f'}] * 100000,
@@ -483,7 +485,7 @@ class TestS3Proxy(unittest.TestCase):
         put_version_data(dataset_id, version, content)
 
         params = {
-            'query_sql': "SELECT * FROM S3Object[*].topLevel[*] AS t WHERE t.a = 'notexists'"
+            'query-s3-select': "SELECT * FROM S3Object[*].topLevel[*] AS t WHERE t.a = 'notexists'"
         }
         expected_content = json.dumps({
             'rows': []
@@ -562,7 +564,7 @@ class TestS3Proxy(unittest.TestCase):
         put_version_data(dataset_id, version_2, content_2)
 
         params = {
-            'query_sql': "SELECT * FROM S3Object[*].top_level[*] row WHERE row.a = 'y'"
+            'query-s3-select': "SELECT * FROM S3Object[*].top_level[*] row WHERE row.a = 'y'"
         }
         expected_content = json.dumps({
             'rows': [{'a': 'y'}],


### PR DESCRIPTION
This is for

- Clarity: it _is_ S3 Select

- Slightly more future friendliness for other query languages. Specifically, another SQL-based one

There is argument that we should abstract away the internal query language. At the moment, we're not doing that, so it's even slightly misleading to have the more abstract "query_sql". We can always add query_sql later in a backwards-compatible way.

Also using hyphens rather than underscores for consistency with path components