### PR TITLE
feat: track requests via google analytics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Location: /v1/datasets/capital-cities/versions/v0.0.1/data?format=json
 | `APM_SECRET_TOKEN`      | A secret token to authorize requests to the APM Server. | _not shown_
 | `APM_SERVER_URL`        | The URL of the APM server | https://apm.elk.uktrade.digital
 | `ENVIRONMENT`           | The current environment where the application is running | develop
+| `GA_ENDPOINT`           | The endpoint to send analytics info to | _not set_
+| `GA_TRACKING_ID`        | The unique identifier for the google analytics property | _not set_
 
 The below environment variables are also required, but typically populated by PaaS.
 

--- a/mock_google_analytics_app.py
+++ b/mock_google_analytics_app.py
@@ -1,0 +1,64 @@
+from gevent import (
+    monkey,
+)
+monkey.patch_all()
+import gevent
+import signal
+
+from flask import Flask
+from gevent.pywsgi import (
+    WSGIServer,
+)
+from werkzeug.middleware.proxy_fix import (
+    ProxyFix,
+)
+
+
+def google_analytics_app():
+
+    calls = 0
+
+    def start():
+        server.serve_forever()
+
+    def stop():
+        server.stop()
+
+    def _store():
+        nonlocal calls
+        calls += 1
+        return 'OK'
+
+    def _calls():
+        nonlocal calls
+        last_calls = calls
+        calls = 0
+        return str(last_calls)
+
+    app = Flask('app')
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1)
+
+    app.add_url_rule(
+        '/collect', methods=['POST'], view_func=_store
+    )
+
+    app.add_url_rule(
+        '/calls', methods=['POST'], view_func=_calls
+    )
+
+    server = WSGIServer(('0.0.0.0', 9002), app, log=app.logger)
+
+    return start, stop
+
+
+def main():
+
+    start, stop = google_analytics_app()
+
+    gevent.signal_handler(signal.SIGTERM, stop)
+    start()
+    gevent.get_hub().join()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Send pageviews to google analytics without blocking the incoming request
- Disabled if no tracking tag is available in the environment
- Includes an update to tests to get them working on linux
    - Hitting the mock sentry service more than 10 times causes the tests to hang
- Adds a new mock analytics app to allow for testing

Closes: https://trello.com/c/TyJFKLyq/1184-google-analytics-for-visibility-of-usage