### PR TITLE
feature: serve gzip compressed csv's if client accepts gzip encoding

### DIFF
--- a/app.py
+++ b/app.py
@@ -338,6 +338,8 @@ def proxy_app(
         )
 
         if response.status == 404 and gzip_encode:
+            for _ in response.stream(65536, decode_content=False):
+                pass
             body_generator, response = _proxy(
                 s3_key,
                 aws_select_post_body_csv(s3_query) if s3_query is not None else None,

--- a/app_worker.py
+++ b/app_worker.py
@@ -14,6 +14,7 @@ from tidy_json_to_csv import (
     to_csvs,
 )
 import urllib3
+import zlib
 
 from app_aws import (
     aws_s3_request,
@@ -60,11 +61,36 @@ def ensure_csvs(
             s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv'
             aws_multipart_upload(signed_s3_request, s3_key, chunks)
 
+        def save_csv_compressed(path, chunks):
+            def yield_compressed_bytes(_uncompressed_bytes):
+                # wbits controls whether a header and trailer is included in the output.
+                # 31 means a basic gzip header and trailing checksum will be included in
+                # the output. See https://docs.python.org/3/library/zlib.html#zlib.compressobj
+                compress_obj = zlib.compressobj(wbits=31)
+                for chunk in _uncompressed_bytes:
+                    compressed_bytes = compress_obj.compress(chunk)
+                    if compressed_bytes:
+                        yield compressed_bytes
+
+                compressed_bytes = compress_obj.flush()
+                if compressed_bytes:
+                    yield compressed_bytes
+
+            table = path.replace('_', '-')  # GDS API guidelines prefer dash to underscore
+            s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv.gz'
+            aws_multipart_upload(signed_s3_request, s3_key, yield_compressed_bytes(chunks))
+
         with signed_s3_request('GET', s3_key=f'{dataset_id}/{version}/data.json') as response:
             if response.status != 200:
                 return
             etag = response.headers['etag'].strip('"')
             to_csvs(response.stream(65536), save_csv)
+
+        with signed_s3_request('GET', s3_key=f'{dataset_id}/{version}/data.json') as response:
+            if response.status != 200:
+                return
+            etag = response.headers['etag'].strip('"')
+            to_csvs(response.stream(65536), save_csv_compressed)
 
         etag_key = f'{dataset_id}/{version}/data.json__CSV_VERSION_{CSV_VERSION}__{etag}'
         with signed_s3_request('PUT', s3_key=etag_key) as response:

--- a/test.py
+++ b/test.py
@@ -271,6 +271,34 @@ class TestS3Proxy(unittest.TestCase):
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
+    def test_table_serves_uncompressed_if_s3_select_query_provided(self, _):
+        dataset_id = str(uuid.uuid4())
+        content = \
+            'col_a,col_b\na,b\nc🍰é,d\ne,d\n&>,d\n' \
+            '"Ah, a comma",d\n"A quote "" ",d\n\\u00f8C,d'.encode(
+                'utf-8')
+        table = 'table'
+        version = 'v0.0.1'
+        put_version_table(dataset_id, version, table, content)
+        put_version_table_gzipped(dataset_id, version, table, content)
+        params = {
+            'query-s3-select': 'SELECT col_a FROM S3Object[*] WHERE col_b = \'d\''
+        }
+        with \
+                requests.Session() as session, \
+                session.get(version_table_public_url_download(dataset_id, version, table),
+                            params=params, headers={'accept-encoding': 'gzip'}
+                            ) as response:
+            self.assertEqual(
+                response.content, 'c🍰é\ne\n&>'
+                '\n"Ah, a comma"\n"A quote "" "\n\\u00f8C\n'.encode('utf-8'))
+            self.assertEqual(response.headers['content-type'], 'text/csv')
+            self.assertEqual(response.headers['content-disposition'],
+                             f'attachment; filename="{dataset_id}--{version}--{table}.csv"')
+            self.assertNotIn('content-encoding', response.headers)
+            self.assertEqual(len(response.history), 0)
+
+    @with_application(8080)
     def test_table_s3_select(self, _):
         dataset_id = str(uuid.uuid4())
         # Note that unlike JSON, a unicode escape sequence like \u00f8C is not an encoded
@@ -291,7 +319,6 @@ class TestS3Proxy(unittest.TestCase):
                 requests.Session() as session, \
                 session.get(version_table_public_url_download(dataset_id, version, table),
                             params=params) as response:
-            print(response)
             self.assertEqual(
                 response.content, 'c🍰é\ne\n&>'
                 '\n"Ah, a comma"\n"A quote "" "\n\\u00f8C\n'.encode('utf-8'))

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@ from datetime import (
 )
 import hashlib
 import hmac
+import gzip
 import itertools
 import json
 import os
@@ -211,6 +212,62 @@ class TestS3Proxy(unittest.TestCase):
             self.assertEqual(response.headers['content-type'], 'text/csv')
             self.assertEqual(response.headers['content-disposition'],
                              f'attachment; filename="{dataset_id}--{version}--{table}.csv"')
+            self.assertEqual(len(response.history), 0)
+
+    @with_application(8080)
+    def test_table_gzipped(self, _):
+        dataset_id = str(uuid.uuid4())
+        content = str(uuid.uuid4()).encode() * 100000
+        table = 'table'
+        version = 'v0.0.1'
+        put_version_table(dataset_id, version, table, content)
+        put_version_table_gzipped(dataset_id, version, table, content)
+
+        with \
+                requests.Session() as session, \
+                session.get(version_table_public_url_download(dataset_id, version, table),
+                            headers={'accept-encoding': None}
+                            ) as response:
+            self.assertEqual(response.content, content)
+            self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'text/csv')
+            self.assertEqual(response.headers['content-disposition'],
+                             f'attachment; filename="{dataset_id}--{version}--{table}.csv"')
+            self.assertNotIn('content-encoding', response.headers)
+            self.assertEqual(len(response.history), 0)
+
+        with \
+                requests.Session() as session, \
+                session.get(version_table_public_url_download(dataset_id, version, table),
+                            headers={'accept-encoding': 'gzip'}
+                            ) as response:
+            self.assertEqual(response.content, content)
+            self.assertEqual(response.headers['content-length'], str(len(gzip.compress(content))))
+            self.assertEqual(response.headers['content-type'], 'text/csv')
+            self.assertEqual(response.headers['content-encoding'], 'gzip')
+            self.assertEqual(response.headers['content-disposition'],
+                             f'attachment; filename="{dataset_id}--{version}--{table}.csv"')
+            self.assertEqual(len(response.history), 0)
+
+    @with_application(8080)
+    def test_table_serves_uncompressed_if_gzip_file_does_not_exist(self, _):
+        dataset_id = str(uuid.uuid4())
+        content = str(uuid.uuid4()).encode() * 100000
+        table = 'table'
+        version = 'v0.0.1'
+        put_version_table(dataset_id, version, table, content)
+
+        with \
+                requests.Session() as session, \
+                session.get(version_table_public_url_download(dataset_id, version, table),
+                            headers={'accept-encoding': 'gzip'}
+                            ) as response:
+            self.assertEqual(response.content, content)
+            self.assertEqual(response.headers['content-length'], str(len(content)))
+            self.assertEqual(response.headers['content-type'], 'text/csv')
+            self.assertEqual(response.headers['content-disposition'],
+                             f'attachment; filename="{dataset_id}--{version}--{table}.csv"')
+            self.assertNotIn('content-encoding', response.headers)
             self.assertEqual(len(response.history), 0)
 
     @with_application(8080)
@@ -1052,6 +1109,9 @@ class TestS3Proxy(unittest.TestCase):
         nested_bytes, _ = get_csv_data(dataset_id, version, 'top--nested')
         self.assertEqual(nested_bytes, b'"top__id","key_2"\r\n1,"value_2"\r\n')
 
+        top_bytes, top_headers = get_csv_data_gzipped(dataset_id, version, 'top')
+        self.assertEqual(gzip.decompress(top_bytes), b'"id","key"\r\n1,"value"\r\n')
+
         time.sleep(12)
 
         # Ensure that we haven't unnecessarily recreated the CSVs
@@ -1207,8 +1267,18 @@ def put_version_table(dataset_id, version, table, contents):
     return put_object(f'{dataset_id}/{version}/tables/{table}/data.csv', contents)
 
 
+def put_version_table_gzipped(dataset_id, version, table, contents):
+    return put_object(
+        f'{dataset_id}/{version}/tables/{table}/data.csv.gz', gzip.compress(contents)
+    )
+
+
 def get_csv_data(dataset_id, version, table):
     return get_object(f'{dataset_id}/{version}/tables/{table}/data.csv')
+
+
+def get_csv_data_gzipped(dataset_id, version, table):
+    return get_object(f'{dataset_id}/{version}/tables/{table}/data.csv.gz')
 
 
 def put_object(key, contents):


### PR DESCRIPTION
Some of the CSVs served by the public data api are quite large, this PR addresses this by returning a gzipped version of the CSV if the client passes an 'Accept-Encoding: gzip' header. The app_worker was changed to produce a gzipped version of each CSV alongside the original CSV.

https://trello.com/c/B57RhXkV/1333-faster-downloads-from-the-gateway-gzip-csv-files