### PR TITLE
fix: edge case where could re-read the same data from the stream

### DIFF
--- a/app_aws.py
+++ b/app_aws.py
@@ -242,6 +242,7 @@ def aws_select_parse_result(convert_records_to_output, input_iterable, min_outpu
                 yield chunk[offset:offset + to_yield]
                 amt -= to_yield
                 offset += to_yield % len(chunk)
+                chunk = chunk if offset else b''
 
             # Yield the rest as it comes in
             while amt:


### PR DESCRIPTION
When offset gets set to 0, it should _not_ use the same chunk again. However, this is exactly what would happen if, say, the client requested 4 bytes and the existing chunk was exactly 4 bytes long.