### PR TITLE
feat: gracefully close APM

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,6 +97,7 @@ def proxy_app(
         server.serve_forever()
 
     def stop():
+        apm.client.close()
         server.stop()
 
     def track_analytics(handler):
@@ -511,8 +512,7 @@ def proxy_app(
         resp.headers['X-Robots-Tag'] = 'no-index, no-follow'
         return resp
 
-    apm = ElasticAPM()
-    apm.init_app(
+    apm = ElasticAPM(
         app,
         service_name='public-data-api',
         secret_token=os.environ['APM_SECRET_TOKEN'],

--- a/test_app.py
+++ b/test_app.py
@@ -69,7 +69,7 @@ def with_application(port, max_attempts=500, aws_access_key_id='AKIAIOSFODNN7EXA
             def stop():
                 time.sleep(0.10)  # Sentry needs some extra time to log any errors
                 for _, process in processes.items():
-                    process.kill()
+                    process.terminate()
                 for _, process in processes.items():
                     process.wait(timeout=5)
                 output_errors = {


### PR DESCRIPTION
This allows tests to use "terminate", which also saved code coverage for the various processes