### PR TITLE
docs: avoid abbreviations and underscores in ids

### DIFF
--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -63,10 +63,10 @@
                       <a href="#api"><span>API Endpoints</span></a>
                       <ul>
                         <li>
-                          <a href="#fetch_specific"><span>GET specific version of a dataset</span></a>
+                          <a href="#get-specific-version"><span>GET specific version of a dataset</span></a>
                         </li>
                         <li>
-                          <a href="#fetch_latest"><span>GET latest version of a dataset</span></a>
+                          <a href="#get-latest-version"><span>GET latest version of a dataset</span></a>
                         </li>
                       </ul>
                     </li>
@@ -93,9 +93,9 @@
             <!-- API -->
             <h2 id="api">API Endpoints</h2>
 
-            <h3 id="fetch_specific">GET specific version of a dataset</h3>
+            <h3 id="get-specific-version">GET specific version of a dataset</h3>
             <pre><code class="hljs html">GET /v1/datasets/:dataset-id/versions/:version/data</code></pre>
-            <h4 id="fetch_specific_qs">Query string parameters</h4>
+            <h4 id="get-specific-version-query-string-parameters">Query string parameters</h4>
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
@@ -122,14 +122,14 @@
                 </tr>
               </tbody>
             </table>
-            <h4 id="fetch_specific_range">Range requests</h4>
+            <h4 id="get-specific-version-range-requests">Range requests</h4>
             <p>If a <code class="hljs html">query-s3-select</code> is <i>not</i> specified, the <code class="hljs html">range</code> HTTP header can be passed to select a byte-range of the dataset. See <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests">HTTP Range Requests</a> for more details.</p>
 
-            <h4 id="fetch_specific_ex1">Example without a query</h4>
-            <h5 id="fetch_specific_ex1_request">Request</h5>
+            <h4 id="get-specific-version-example-without-query">Example without a query</h4>
+            <h5 id="get-specific-version-example-without-query-request">Request</h5>
             <pre><code class="hljs html">GET /v1/datasets/capital-cities/versions/v0.0.1/data?format=json</code></pre>
 
-            <h5 id="fetch_specific_ex1_response">Response</h5>
+            <h5 id="get-specific-version-example-without-a-query-response">Response</h5>
             <pre><code class="hljs html">Status: 200 OK
 {
     "capital_cities": [
@@ -139,14 +139,14 @@
     ]
 }</code></pre>
 
-            <h4 id="fetch_specific_ex2">Example with a query</h4>
-            <h5 id="fetch_specific_ex2_request">Request</h5>
+            <h4 id="get-specific-version-example-with-query">Example with a query</h4>
+            <h5 id="get-specific-version-example-with-request">Request</h5>
             <pre><code class="hljs html">GET /v1/datasets/capital-cities/versions/v0.0.1/data?format=json&query-s3-select=...</code></pre>
             where <code class="hljs html">...</code> is the below, but URL-encoded
 
             <pre><code class="hljs psql">SELECT * FROM S3Object[*].capital_cities[*] AS city WHERE city.iso_2_country_code = 'Paris'</code></pre>
 
-            <h5 id="fetch_specific_ex2_response">Response</h5>
+            <h5 id="get-specific-version-example-with-query-response">Response</h5>
             <pre><code class="hljs html">Status: 200 OK
 {
     "rows": [
@@ -154,9 +154,9 @@
     ]
 }</code></pre>
 
-            <h3 id="fetch_latest">GET latest version of a dataset</h3>
+            <h3 id="get-latest-version">GET latest version of a dataset</h3>
             <pre><code class="hljs html">GET /v1/datasets/:dataset-id/versions/:version/data</code></pre>
-            <h4 id="fetch_latest_qs">Query string parameters</h4>
+            <h4 id="get-latest-version-query-string-parameters">Query string parameters</h4>
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
@@ -184,11 +184,11 @@
               </tbody>
             </table>
 
-            <h4 id="fetch_latest_ex">Example</h4>
-            <h5 id="fetch_latest_request">Request</h5>
+            <h4 id="get-latest-version-example">Example</h4>
+            <h5 id="get-latest-version-example-request">Request</h5>
             <pre><code class="hljs html">GET /v1/datasets/capital-cities/versions/latest/data?format=json</code></pre>
 
-            <h5 id="fetch_latest_response">Response</h5>
+            <h5 id="get-latest-version-example-response">Response</h5>
             <pre><code class="hljs html">Status: 302 Found
 Location: /v1/datasets/capital-cities/versions/v0.0.1/data?format=json</code></pre>
 


### PR DESCRIPTION
Avoiding underscores is informed by https://www.gov.uk/guidance/gds-api-technical-and-data-standards where it states:

> use hyphens rather than underscores as word separators for multiword names