### PR TITLE
docs: clearer README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,22 @@ pip install -r requirements_test.txt  # Only required once
 
 ## Running locally
 
+Most development can be done from tests. However, it can be useful to run the front end of the application locally to work on the documentation. The below results in the documentation being visible at http://localhost:8888/
+
 ```bash
 pip install -r requirements.txt  # Only required once
-python3 -m app
+PORT=8888 \
+READONLY_AWS_ACCESS_KEY_ID=any \
+READONLY_AWS_SECRET_ACCESS_KEY=any \
+AWS_S3_ENDPOINT=http://any/ \
+AWS_S3_REGION=any \
+APM_SECRET_TOKEN=any \
+APM_SERVER_URL=any \
+ENVIRONMENT=any \
+DOCS_DEPARTMENT_NAME='Department for International Trade' \
+DOCS_SERVICE_NAME='Data API' \
+DOCS_GITHUB_REPO_URL=https://github.com/uktrade/public-data-api \
+    python3 -m app
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ Exposes datasets stored in S3-compatible object storage with a light-touch API.
 ## Running tests
 
 ```bash
-./start-services.sh  # Only required once
+pip install -r requirements_test.txt  # Only required once
+./start-services.sh                   # Only required once
 ./test_app.sh
 ```
 
 
 ## Running locally
 
-```
+```bash
+pip install -r requirements.txt  # Only required once
 python3 -m app
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ Exposes datasets stored in S3-compatible object storage with a light-touch API.
 - [HTTP Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) are not used
 
 
----
+## Running tests
 
-## Technical requirements
+```bash
+./start-services.sh  # Only required once
+./test_app.sh
+```
 
-### Environment variables
+
+## Running locally
+
+```
+python3 -m app
+```
+
+
+## Environment variables
 
 | Variable                | Description | Example |
 | ---                     | ---         | ---     |
@@ -50,26 +61,12 @@ The below environment variables are also required, but typically populated by Pa
 | ---             | ---         | ---     |
 | `PORT`          | The port for the application to listen on | `8080`
 
-### Permissions and 404s
+
+## Permissions and 404s
 
 If the AWS user has the ListBucket permission, 404s are proxied through to the user to aid debugging.
 
 
-### Shutdown
+## Shutdown
 
 On SIGTERM any in-progress requests will complete before the process exits. At the time of writing PaaS will then forcibly kill the process with SIGKILL if it has not exited within 10 seconds.
-
-
-### Running locally
-
-```
-python3 -m app
-```
-
-
-### Running tests
-
-```bash
-./start-services.sh  # Only required once
-./test_app.sh
-```


### PR DESCRIPTION
Now the API documentation is elsewhere, the README can specialise in information that's useful for development. So am putting the most relevant stuff for that up front. Specifically, how to run the tests is in prime position, and then how to run the application. It's deliberately in that order, since from tests is the preferred way to develop the API.