### PR TITLE
feat: shorter header in more cases

### DIFF
--- a/static/docs.css
+++ b/static/docs.css
@@ -3567,3 +3567,10 @@
 
 .fixedsticky-on + .fixedsticky-dummy {
   display: block; }
+
+/* Changes that are not part of the original docs.css */
+@media (min-width: 48.0625em) {
+  .app-header .govuk-header__logo {
+    width: 80%; }
+  .app-header .govuk-header__content {
+    width: 20%; } }


### PR DESCRIPTION
<img width="1239" alt="Screenshot 2021-11-30 at 06 44 52" src="https://user-images.githubusercontent.com/13877/143998949-28c855b0-9774-40df-bbfb-89e2d4a91c24.png">

instead of what there is before this PR

<img width="1239" alt="Screenshot 2021-11-30 at 06 44 50" src="https://user-images.githubusercontent.com/13877/143998978-d5b47161-7238-4e1d-bdf9-3b02dd929929.png">


