### PR TITLE
refactor: to support sqlite to csv generation

### DIFF
--- a/app_worker.py
+++ b/app_worker.py
@@ -51,7 +51,7 @@ def ensure_csvs(
             for version in aws_list_folders(signed_s3_request, f'{dataset_id}/'):
                 yield dataset_id, version
 
-    def write_csvs(dataset_id, version):
+    def convert_json_to_csvs(dataset_id, version):
         def save_csv(path, chunks):
             table = path.replace('_', '-')  # GDS API guidelines prefer dash to underscore
             s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv'
@@ -96,7 +96,7 @@ def ensure_csvs(
             continue
 
         try:
-            write_csvs(dataset_id, version)
+            convert_json_to_csvs(dataset_id, version)
         except Exception:
             logger.exception('Exception writing CSVs %s %s', dataset_id, version)
             continue

--- a/app_worker.py
+++ b/app_worker.py
@@ -86,11 +86,12 @@ def ensure_csvs(
         if shut_down.is_set():
             break
 
-        status, headers = aws_head(signed_s3_request, f'{dataset_id}/{version}/data.json')
+        json_s3_key = f'{dataset_id}/{version}/data.json'
+        status, headers = aws_head(signed_s3_request, json_s3_key)
         if status != 200:
             continue
         etag = headers['etag'].strip('"')
-        etag_key = f'{dataset_id}/{version}/data.json__CSV_VERSION_{CSV_VERSION}__{etag}'
+        etag_key = f'{json_s3_key}__CSV_VERSION_{CSV_VERSION}__{etag}'
         status, _ = aws_head(signed_s3_request, etag_key)
         if status == 200:
             continue
@@ -108,7 +109,7 @@ def ensure_csvs(
                     return
                 save_csv_compressed(dataset_id, version, table, response.stream(65536))
 
-        status, headers = aws_head(signed_s3_request, f'{dataset_id}/{version}/data.json')
+        status, headers = aws_head(signed_s3_request, json_s3_key)
         if status != 200:
             continue
         if etag != headers['etag'].strip('"'):

--- a/app_worker.py
+++ b/app_worker.py
@@ -103,8 +103,8 @@ def ensure_csvs(
             continue
 
         for table in aws_list_folders(signed_s3_request, f'{dataset_id}/{version}/tables/'):
-            s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv'
-            with signed_s3_request('GET', s3_key=s3_key) as response:
+            csv_s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv'
+            with signed_s3_request('GET', s3_key=csv_s3_key) as response:
                 if response.status != 200:
                     return
                 save_csv_compressed(dataset_id, version, table, response.stream(65536))


### PR DESCRIPTION
The main point of this PR is to have the structure of the main conversion loop be more like

1. ~code common to JSON and SQLite datasets
2. convert_json_to_csvs
3. ~code common to JSON and SQLite datasets

to be able to more easily add in different conversions in step 2

The second point of this PR is reducing the nesting level of functions/how many functions there are. To me, this makes the main loop a touch clearer.

----

Reviews can be commit-by-commit: each should be a step forward in the overall refactor