### PR TITLE
build(deps): upgrade pip-tools

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -88,7 +88,9 @@ nodeenv==1.3.3
     # via pre-commit
 packaging==20.4
     # via pytest
-pip-tools==5.3.1
+pep517==0.12.0
+    # via pip-tools
+pip-tools==6.4.0
     # via -r requirements_test.in
 platformdirs==2.4.0
     # via virtualenv
@@ -116,7 +118,6 @@ six==1.12.0
     # via
     #   cfgv
     #   packaging
-    #   pip-tools
     #   virtualenv
 tidy-json-to-csv==0.0.13
     # via -r requirements.txt
@@ -124,6 +125,8 @@ toml==0.10.0
     # via
     #   pre-commit
     #   pytest
+tomli==1.2.2
+    # via pep517
 typing-extensions==4.0.0
     # via astroid
 urllib3==1.26.5
@@ -138,6 +141,8 @@ werkzeug==0.15.5
     # via
     #   -r requirements.txt
     #   flask
+wheel==0.37.0
+    # via pip-tools
 wrapt==1.11.2
     # via astroid
 zope.event==4.4


### PR DESCRIPTION
Suspect the existing requirements files were already made not using the version specified, since they mentioned Python version, which is a recent pip-tools feature