### PR TITLE
refactor: allow not sending delimiter when listing S3 keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,7 +177,8 @@ def proxy_app(
                 v_major_str, minor_str, patch_str = path.split('.')
                 return (int(v_major_str[1:]), int(minor_str), int(patch_str))
 
-            folders = aws_list(signed_s3_request, request.view_args['dataset_id'] + '/', '/')
+            folders = aws_list(signed_s3_request,
+                               prefix=request.view_args['dataset_id'] + '/', delimeter='/')
             matching_folders = filter(predicate, folders)
             latest_matching_version = max(matching_folders, default=None, key=semver_key)
 
@@ -316,7 +317,7 @@ def proxy_app(
     @track_analytics
     @validate_format(('json',))
     def list_all_datasets():
-        folders = aws_list(signed_s3_request, '', '/')
+        folders = aws_list(signed_s3_request, delimeter='/')
         versions = {
             'datasets': [
                 {'id': dataset} for dataset in folders if dataset != 'healthcheck'
@@ -332,7 +333,7 @@ def proxy_app(
             v_major_str, minor_str, patch_str = path.split('.')
             return (int(v_major_str[1:]), int(minor_str), int(patch_str))
 
-        folders = aws_list(signed_s3_request, dataset_id + '/', '/')
+        folders = aws_list(signed_s3_request, prefix=dataset_id + '/', delimeter='/')
         sorted_versions = sorted(folders, key=semver_key, reverse=True)
         versions = {'versions': [{'id': version} for version in sorted_versions]}
 
@@ -342,7 +343,8 @@ def proxy_app(
     @validate_and_redirect_version
     @validate_format(('json',))
     def list_tables_for_dataset_version(dataset_id, version):
-        folders = aws_list(signed_s3_request, f'{dataset_id}/{version}/tables/', '/')
+        folders = aws_list(signed_s3_request,
+                           prefix=f'{dataset_id}/{version}/tables/', delimeter='/')
         tables = {'tables': [{'id': table} for table in folders]}
 
         return Response(json.dumps(tables), headers={'content-type': 'text/json'}, status=200)
@@ -351,7 +353,8 @@ def proxy_app(
     @validate_and_redirect_version
     @validate_format(('json',))
     def list_reports_for_dataset_version(dataset_id, version):
-        folders = aws_list(signed_s3_request, f'{dataset_id}/{version}/reports/', '/')
+        folders = aws_list(signed_s3_request,
+                           prefix=f'{dataset_id}/{version}/reports/', delimeter='/')
         reports = {'reports': [{'id': report} for report in folders]}
         return Response(json.dumps(reports), headers={'content-type': 'text/json'}, status=200)
 

--- a/app_aws.py
+++ b/app_aws.py
@@ -339,7 +339,7 @@ def aws_list(signed_s3_request, prefix, delimeter):
     namespace = '{http://s3.amazonaws.com/doc/2006-03-01/}'
     token = ''
 
-    def _list(extra_query_items=()):
+    def _list(extra_query_params=()):
         nonlocal token
 
         token = ''
@@ -348,7 +348,7 @@ def aws_list(signed_s3_request, prefix, delimeter):
             ('list-type', '2'),
             ('delimiter', delimeter),
             ('prefix', prefix),
-        ) + extra_query_items
+        ) + extra_query_params
         with signed_s3_request('GET', s3_key='', params=query) as response:
             body_bytes = response.read()
 

--- a/app_aws.py
+++ b/app_aws.py
@@ -335,7 +335,7 @@ def aws_select_parse_result(convert_records_to_output, input_iterable, min_outpu
     return output
 
 
-def aws_list(signed_s3_request, prefix, delimeter):
+def aws_list(signed_s3_request, prefix=None, delimeter=None):
     namespace = '{http://s3.amazonaws.com/doc/2006-03-01/}'
     token = ''
 
@@ -346,9 +346,10 @@ def aws_list(signed_s3_request, prefix, delimeter):
         query = (
             ('max-keys', '1000'),
             ('list-type', '2'),
-            ('delimiter', delimeter),
-            ('prefix', prefix),
-        ) + extra_query_params
+        ) + \
+            ((('prefix', prefix),) if prefix is not None else ()) + \
+            ((('delimiter', delimeter),) if delimeter is not None else ()) + \
+            extra_query_params
         with signed_s3_request('GET', s3_key='', params=query) as response:
             body_bytes = response.read()
 
@@ -358,7 +359,7 @@ def aws_list(signed_s3_request, prefix, delimeter):
         for element in ET.fromstring(body_bytes):
             if element.tag == f'{namespace}CommonPrefixes':
                 for child in element:
-                    yield child.text[len(prefix):-1]
+                    yield child.text[len(prefix if prefix is not None else ''):-1]
             if element.tag == f'{namespace}NextContinuationToken':
                 token = element.text
 

--- a/app_worker.py
+++ b/app_worker.py
@@ -44,11 +44,11 @@ def ensure_csvs(
                                 aws_access_key_id, aws_secret_access_key, region_name)
 
     def get_dataset_ids():
-        yield from aws_list(signed_s3_request, '', '/')
+        yield from aws_list(signed_s3_request, delimeter='/')
 
     def get_dataset_ids_versions(dataset_ids):
         for dataset_id in dataset_ids:
-            for version in aws_list(signed_s3_request, f'{dataset_id}/', '/'):
+            for version in aws_list(signed_s3_request, prefix=f'{dataset_id}/', delimeter='/'):
                 yield dataset_id, version
 
     def convert_json_to_csvs(dataset_id, version):
@@ -106,7 +106,8 @@ def ensure_csvs(
             continue
 
         # Compress the CSVs
-        for table in aws_list(signed_s3_request, f'{dataset_id}/{version}/tables/', '/'):
+        for table in aws_list(signed_s3_request,
+                              prefix=f'{dataset_id}/{version}/tables/', delimeter='/'):
             csv_s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv'
             with signed_s3_request('GET', s3_key=csv_s3_key) as response:
                 if response.status != 200:


### PR DESCRIPTION
The change in 0455904fa3b211bd241f797d44ce77368a81da85 didn't quite achieve this: the delimiter parameter has to not be sent