### PR TITLE
refactor: specialise function to just folders

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,7 +58,7 @@ from app_aws import (
     aws_select_convert_records_to_csv,
     aws_select_convert_records_to_json,
     aws_select_parse_result,
-    aws_list,
+    aws_list_folders,
 )
 
 
@@ -177,8 +177,8 @@ def proxy_app(
                 v_major_str, minor_str, patch_str = path.split('.')
                 return (int(v_major_str[1:]), int(minor_str), int(patch_str))
 
-            folders = aws_list(signed_s3_request,
-                               prefix=request.view_args['dataset_id'] + '/', delimeter='/')
+            folders = aws_list_folders(signed_s3_request,
+                                       prefix=request.view_args['dataset_id'] + '/')
             matching_folders = filter(predicate, folders)
             latest_matching_version = max(matching_folders, default=None, key=semver_key)
 
@@ -317,7 +317,7 @@ def proxy_app(
     @track_analytics
     @validate_format(('json',))
     def list_all_datasets():
-        folders = aws_list(signed_s3_request, delimeter='/')
+        folders = aws_list_folders(signed_s3_request)
         versions = {
             'datasets': [
                 {'id': dataset} for dataset in folders if dataset != 'healthcheck'
@@ -333,7 +333,7 @@ def proxy_app(
             v_major_str, minor_str, patch_str = path.split('.')
             return (int(v_major_str[1:]), int(minor_str), int(patch_str))
 
-        folders = aws_list(signed_s3_request, prefix=dataset_id + '/', delimeter='/')
+        folders = aws_list_folders(signed_s3_request, prefix=dataset_id + '/')
         sorted_versions = sorted(folders, key=semver_key, reverse=True)
         versions = {'versions': [{'id': version} for version in sorted_versions]}
 
@@ -343,8 +343,7 @@ def proxy_app(
     @validate_and_redirect_version
     @validate_format(('json',))
     def list_tables_for_dataset_version(dataset_id, version):
-        folders = aws_list(signed_s3_request,
-                           prefix=f'{dataset_id}/{version}/tables/', delimeter='/')
+        folders = aws_list_folders(signed_s3_request, prefix=f'{dataset_id}/{version}/tables/')
         tables = {'tables': [{'id': table} for table in folders]}
 
         return Response(json.dumps(tables), headers={'content-type': 'text/json'}, status=200)
@@ -353,8 +352,7 @@ def proxy_app(
     @validate_and_redirect_version
     @validate_format(('json',))
     def list_reports_for_dataset_version(dataset_id, version):
-        folders = aws_list(signed_s3_request,
-                           prefix=f'{dataset_id}/{version}/reports/', delimeter='/')
+        folders = aws_list_folders(signed_s3_request, prefix=f'{dataset_id}/{version}/reports/')
         reports = {'reports': [{'id': report} for report in folders]}
         return Response(json.dumps(reports), headers={'content-type': 'text/json'}, status=200)
 

--- a/app_aws.py
+++ b/app_aws.py
@@ -335,7 +335,7 @@ def aws_select_parse_result(convert_records_to_output, input_iterable, min_outpu
     return output
 
 
-def aws_list(signed_s3_request, prefix=None, delimeter=None):
+def aws_list_folders(signed_s3_request, prefix=None):
     namespace = '{http://s3.amazonaws.com/doc/2006-03-01/}'
     token = ''
 
@@ -346,9 +346,9 @@ def aws_list(signed_s3_request, prefix=None, delimeter=None):
         query = (
             ('max-keys', '1000'),
             ('list-type', '2'),
+            ('delimiter', '/'),
         ) + \
             ((('prefix', prefix),) if prefix is not None else ()) + \
-            ((('delimiter', delimeter),) if delimeter is not None else ()) + \
             extra_query_params
         with signed_s3_request('GET', s3_key='', params=query) as response:
             body_bytes = response.read()

--- a/app_worker.py
+++ b/app_worker.py
@@ -26,7 +26,7 @@ import zlib
 
 from app_aws import (
     aws_s3_request,
-    aws_list,
+    aws_list_folders,
     aws_head,
     aws_multipart_upload,
 )
@@ -44,11 +44,11 @@ def ensure_csvs(
                                 aws_access_key_id, aws_secret_access_key, region_name)
 
     def get_dataset_ids():
-        yield from aws_list(signed_s3_request, delimeter='/')
+        yield from aws_list_folders(signed_s3_request)
 
     def get_dataset_ids_versions(dataset_ids):
         for dataset_id in dataset_ids:
-            for version in aws_list(signed_s3_request, prefix=f'{dataset_id}/', delimeter='/'):
+            for version in aws_list_folders(signed_s3_request, prefix=f'{dataset_id}/'):
                 yield dataset_id, version
 
     def convert_json_to_csvs(dataset_id, version):
@@ -106,8 +106,7 @@ def ensure_csvs(
             continue
 
         # Compress the CSVs
-        for table in aws_list(signed_s3_request,
-                              prefix=f'{dataset_id}/{version}/tables/', delimeter='/'):
+        for table in aws_list_folders(signed_s3_request, prefix=f'{dataset_id}/{version}/tables/'):
             csv_s3_key = f'{dataset_id}/{version}/tables/{table}/data.csv'
             with signed_s3_request('GET', s3_key=csv_s3_key) as response:
                 if response.status != 200:


### PR DESCRIPTION
Going a bit back and forth on this one, but now think clearer to just have separate functions for querying for keys and querying for folders, since they access different XML, and could return different data (e.g. keys can have a last-modified, but folders don't).