### PR TITLE
feat: allow CORS

### DIFF
--- a/app.py
+++ b/app.py
@@ -677,7 +677,7 @@ def proxy_app(
 
     @app.after_request
     def _add_noindex_header(resp):
-        resp.headers['X-Robots-Tag'] = 'no-index, no-follow'
+        resp.headers['x-robots-tag'] = 'no-index, no-follow'
         return resp
 
     apm = ElasticAPM(

--- a/app.py
+++ b/app.py
@@ -677,6 +677,7 @@ def proxy_app(
 
     @app.after_request
     def _add_noindex_header(resp):
+        resp.headers['access-control-allow-origin'] = '*'
         resp.headers['x-robots-tag'] = 'no-index, no-follow'
         return resp
 

--- a/test_app.py
+++ b/test_app.py
@@ -1656,7 +1656,7 @@ def test_healthcheck_fail(processes):
         assert response.status_code == 503
 
 
-def test_noindex_header(processes):
+def test_headers(processes):
     dataset_id = str(uuid.uuid4())
     content_str = {'foo': 'bar'}
     content = json.dumps(content_str).encode()

--- a/test_app.py
+++ b/test_app.py
@@ -1666,6 +1666,7 @@ def test_headers(processes):
     data_url = version_data_public_url(dataset_id, version, 'json')
     with requests.Session() as session, session.get(data_url) as response:
         assert response.status_code == 200
+        assert response.headers['access-control-allow-origin'] == '*'
         assert response.headers['x-robots-tag'] == 'no-index, no-follow'
 
 

--- a/test_app.py
+++ b/test_app.py
@@ -1666,7 +1666,7 @@ def test_noindex_header(processes):
     data_url = version_data_public_url(dataset_id, version, 'json')
     with requests.Session() as session, session.get(data_url) as response:
         assert response.status_code == 200
-        assert response.headers['X-Robots-Tag'] == 'no-index, no-follow'
+        assert response.headers['x-robots-tag'] == 'no-index, no-follow'
 
 
 def test_sentry_integration(processes_bad_key):


### PR DESCRIPTION
 This was a bit of an oversight that we didn't have this from the get-go. Note, there is no sign in or any way to modify any data from the API, and absolutely everything served by the API (and in the bucket that powers it) is for the public.