### PR TITLE
docs: avoid fixed table width columns for better mobile view

### DIFF
--- a/static/docs.css
+++ b/static/docs.css
@@ -3574,3 +3574,7 @@
     width: 80%; }
   .app-header .govuk-header__content {
     width: 20%; } }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -141,19 +141,19 @@
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">dataset</code></td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">dataset</code></td>
                   <td class="govuk-table__cell">A human-readable identifier of the dataset, e.g. <code>{{ dataset }}</code></td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">version</code></td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">version</code></td>
                   <td class="govuk-table__cell">
-                      <p>A version in the format <code class="hljs html">vX.Y.Z</code>, where <code class="hljs html">X.Y.Z</code> is the <a href="https://semver.org/">Semver 2.0</a> version of the dataset, e.g. <code>{{ version }}</code></p>
+                      <p>A version in the format <code class="hljs html nowrap">vX.Y.Z</code>, where <code class="hljs html">X.Y.Z</code> is the <a href="https://semver.org/">Semver 2.0</a> version of the dataset, e.g. <code>{{ version }}</code></p>
                       <p>or</p>
                       <p>A version in the format <code class="hljs html">vX.Y</code>. In this case, a HTTP 302 redirect is returned to the original URL requested, but with <code class="hljs html">version</code> replaced with the latest <code class="hljs html">vX.Y</code> version of the dataset</p>
                       <p>or</p>
@@ -163,7 +163,7 @@
                   </td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">table</code></td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">table</code></td>
                   <td class="govuk-table__cell">A human-readable table name, e.g. <code>{{ table_name }}</code></td>
                 </tr>
               </tbody>
@@ -177,13 +177,13 @@
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">format</code> (required)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code> (required)</td>
                   <td class="govuk-table__cell">The requested output format. In all cases, this must be <code class="hljs html">json</code></td>
                 </tr>
               </tbody>
@@ -206,13 +206,13 @@
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">format</code> (required)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code> (required)</td>
                   <td class="govuk-table__cell">The requested output format. In all cases, this must be <code class="hljs html">json</code></td>
                 </tr>
               </tbody>
@@ -235,13 +235,13 @@
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">format</code> (required)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code> (required)</td>
                   <td class="govuk-table__cell">The requested output format. In all cases, this must be <code class="hljs html">json</code></td>
                 </tr>
               </tbody>
@@ -275,17 +275,17 @@ Location: /v1/datasets/{{ dataset }}/versions/{{ latest_version }}/tables?format
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">format</code> (required)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code> (required)</td>
                   <td class="govuk-table__cell">The requested output format. This must be <code class="hljs html">csvw</code> or <code class="hljs html">html</code></td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">download</code> (optional)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">download</code> (optional)</td>
                   <td class="govuk-table__cell">The presence of this parameter results in a <code class="hljs html">content-disposition</code> header so that browsers attempt to download the metadata rather than display it inline</td>
                 </tr>
               </tbody>
@@ -322,17 +322,17 @@ Location: /v1/datasets/{{ dataset }}/versions/{{ latest_version }}/tables?format
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">format</code> (required)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code> (required)</td>
                   <td class="govuk-table__cell">The requested output format. This must be <code class="hljs html">sqlite</code> or <code class="hljs html">json</code></td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">query-s3-select</code> (optional)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">query-s3-select</code> (optional)</td>
                   <td class="govuk-table__cell">
                     <p>A query using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference-select.html">S3 Select query language</a>,  e.g. <code class="hljs psql">SELECT * FROM S3Object[*]</code></p>
                     <p>The response is a JSON object with the query results under the <code class="hljs html">rows</code> key, i.e. <code class="hljs html">{"rows": [...]}</code></p>
@@ -340,7 +340,7 @@ Location: /v1/datasets/{{ dataset }}/versions/{{ latest_version }}/tables?format
                   </td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">download</code> (optional)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">download</code> (optional)</td>
                   <td class="govuk-table__cell">The presence of this parameter results in a <code class="hljs html">content-disposition</code> header so that browsers attempt to download the data rather than display it inline.</td>
                 </tr>
               </tbody>
@@ -397,17 +397,17 @@ Location: /v1/datasets/{{ dataset }}/versions/{{ latest_version }}/data?format=j
             <table class="govuk-table">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+                  <th scope="col" class="govuk-table__header">Name</th>
                   <th scope="col" class="govuk-table__header">Description</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">format</code> (required)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code> (required)</td>
                   <td class="govuk-table__cell">The requested output format. In all cases, this must be <code class="hljs html">csv</code></td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td scope="row" class="govuk-table__cell"><code class="hljs html">download</code> (optional)</td>
+                  <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">download</code> (optional)</td>
                   <td class="govuk-table__cell">The presence of this parameter results in a <code class="hljs html">content-disposition</code> header so that browsers attempt to download the data rather than display it inline.</td>
                 </tr>
               </tbody>


### PR DESCRIPTION
The columns were much too wide on mobile view. So instead of
<img width="677" alt="Screenshot 2021-12-12 at 11 09 04" src="https://user-images.githubusercontent.com/13877/145709929-b230a3e3-d16f-4e09-8f23-f5632531e202.png">

we now have

<img width="677" alt="Screenshot 2021-12-12 at 11 09 06" src="https://user-images.githubusercontent.com/13877/145709935-5d808f8c-9c23-482e-9adf-d2c98190f1bb.png">

