### PR TITLE
feat: send query string to Google Analytics

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,8 +104,8 @@ def proxy_app(
     def track_analytics(handler):
         """Decorator to send analytics data to google in the background."""
 
-        def _send(requester_ip, request_host, request_path, request_headers):
-            logger.info('Sending to Google Analytics %s: %s...', request_host, request_path)
+        def _send(requester_ip, request_url, request_headers):
+            logger.info('Sending to Google Analytics %s...', request_url)
             requests.post(
                 os.environ.get('GA_ENDPOINT', 'https://www.google-analytics.com/collect'),
                 data={
@@ -115,8 +115,7 @@ def proxy_app(
                     't': 'pageview',
                     'uip': requester_ip,
                     'aip': '1',
-                    'dh': request_host,
-                    'dp': request_path,
+                    'dl': request_url,
                     'ds': 'public-data-api',
                     'dr': request_headers.get('referer', ''),
                     'ua': request_headers.get('user-agent', ''),
@@ -129,8 +128,7 @@ def proxy_app(
                 gevent.spawn(
                     _send,
                     request.remote_addr,
-                    request.host_url,
-                    request.path,
+                    request.url,
                     request.headers
                 )
             return handler(*args, **kwargs)

--- a/mock_google_analytics_app.py
+++ b/mock_google_analytics_app.py
@@ -3,9 +3,13 @@ from gevent import (
 )
 monkey.patch_all()
 import gevent
+import json
 import signal
 
-from flask import Flask
+from flask import (
+    Flask,
+    request,
+)
 from gevent.pywsgi import (
     WSGIServer,
 )
@@ -16,7 +20,7 @@ from werkzeug.middleware.proxy_fix import (
 
 def google_analytics_app():
 
-    calls = 0
+    calls = []
 
     def start():
         server.serve_forever()
@@ -26,14 +30,14 @@ def google_analytics_app():
 
     def _store():
         nonlocal calls
-        calls += 1
+        calls.append(request.form)
         return 'OK'
 
     def _calls():
         nonlocal calls
         last_calls = calls
-        calls = 0
-        return str(last_calls)
+        calls = []
+        return json.dumps(last_calls)
 
     app = Flask('app')
     app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1)

--- a/test_app.py
+++ b/test_app.py
@@ -1707,6 +1707,7 @@ def test_google_analytics_integration_on_api(processes):
         response = session.post('http://127.0.0.1:9002/calls')
         calls = json.loads(response.content)
         assert len(calls) == 4
+        assert calls[0]['dp'] == f'/v1/datasets/{dataset_id}/versions/v0.0.1/data'
 
 
 def test_google_analytics_integration_on_docs(processes):

--- a/test_app.py
+++ b/test_app.py
@@ -1705,7 +1705,8 @@ def test_google_analytics_integration_on_api(processes):
 
         time.sleep(1)
         response = session.post('http://127.0.0.1:9002/calls')
-        assert len(json.loads(response.content)) == 4
+        calls = json.loads(response.content)
+        assert len(calls) == 4
 
 
 def test_google_analytics_integration_on_docs(processes):

--- a/test_app.py
+++ b/test_app.py
@@ -1707,7 +1707,8 @@ def test_google_analytics_integration_on_api(processes):
         response = session.post('http://127.0.0.1:9002/calls')
         calls = json.loads(response.content)
         assert len(calls) == 4
-        assert calls[0]['dp'] == f'/v1/datasets/{dataset_id}/versions/v0.0.1/data'
+        assert calls[0]['dl'] == \
+            f'http://127.0.0.1:8080/v1/datasets/{dataset_id}/versions/v0.0.1/data?format=json'
 
 
 def test_google_analytics_integration_on_docs(processes):

--- a/test_app.py
+++ b/test_app.py
@@ -1705,7 +1705,7 @@ def test_google_analytics_integration_on_api(processes):
 
         time.sleep(1)
         response = session.post('http://127.0.0.1:9002/calls')
-        assert int(response.content) == 4
+        assert len(json.loads(response.content)) == 4
 
 
 def test_google_analytics_integration_on_docs(processes):
@@ -1716,7 +1716,7 @@ def test_google_analytics_integration_on_docs(processes):
 
         time.sleep(1)
         response = session.post('http://127.0.0.1:9002/calls')
-        assert int(response.content) == 3
+        assert len(json.loads(response.content)) == 3
 
 
 def test_docs(processes):


### PR DESCRIPTION
This is so we can make more informed decisions on how to change the API later: lots of behaviour is controlled by query strings