### PR TITLE
build(deps): bump stream-write-ods to encode None as empty cells

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ sniffio==1.2.0
     #   httpx
 sqlite-s3-query==0.0.63
     # via -r requirements.in
-stream-write-ods==0.0.18
+stream-write-ods==0.0.21
     # via -r requirements.in
 stream-zip==0.0.46
     # via stream-write-ods

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -170,7 +170,7 @@ sniffio==1.2.0
     #   httpx
 sqlite-s3-query==0.0.63
     # via -r requirements.txt
-stream-write-ods==0.0.18
+stream-write-ods==0.0.21
     # via -r requirements.txt
 stream-zip==0.0.46
     # via


### PR DESCRIPTION
They were encoded as the string #NA, but this was a bit of a hack. Empty cells appear to be a well supported way of saying a cell is... empty.