### PR TITLE
feat: multi-statement reports expose data from each statement

### DIFF
--- a/test_app.py
+++ b/test_app.py
@@ -1719,7 +1719,9 @@ def test_csvs_and_ods_created_from_sqlite_with_reports(processes):
     with \
             requests.Session() as session, \
             session.get(report_url) as response:
-        assert response.content == b'"col_int_a","col_int_b"\r\n3,1\r\n3,2\r\n'
+        assert response.content == \
+            b'"col_int_a","col_int_b"' + \
+            b'\r\n2,2\r\n1,3\r\n3,2\r\n3,1\r\n3,1\r\n3,2\r\n'
 
     report_url = version_public_url_download('report', dataset_id, version, 'my-report', 'ods')
     with \
@@ -1729,12 +1731,26 @@ def test_csvs_and_ods_created_from_sqlite_with_reports(processes):
         with tempfile.NamedTemporaryFile() as f:
             f.write(response.content)
             f.flush()
-            report = pd.read_excel(f.name, 'my_report')
-            report_rows = report.values.tolist()
-            report_cols = report.columns.tolist()
+            report_1 = pd.read_excel(f.name, 'my_report - 1')
+            report_1_rows = report_1.values.tolist()
+            report_1_cols = report_1.columns.tolist()
+            report_2 = pd.read_excel(f.name, 'my_report - 2')
+            report_2_rows = report_2.values.tolist()
+            report_2_cols = report_2.columns.tolist()
 
-    assert report_cols == ['col_int_a', 'col_int_b', ]
-    assert report_rows == [[3.0, 1.0], [3.0, 2.0]]
+    assert report_1_cols == ['col_int_a', 'col_int_b', ]
+    assert report_1_rows == [
+        [2.0, 2.0],
+        [1.0, 3.0],
+        [3.0, 2.0],
+        [3.0, 1.0],
+    ]
+
+    assert report_2_cols == ['col_int_a', 'col_int_b', ]
+    assert report_2_rows == [
+        [3.0, 1.0],
+        [3.0, 2.0],
+    ]
 
 
 def test_logs_ecs_format():


### PR DESCRIPTION
The Public Data API has the concept of "reports" in SQLite-based datasets. These are SQL scripts that define some sort of filtered or aggregated "report" on the data in the SQLite file where each report's data is exposed as a single ODS file, and and single CSV file.

The SQL scripts can be made of multiple statements, for example to create temporary table(s). Then the final statement is a SELECT to query over the temporary table(s) and/or the real tables.

The code, before this change, dealt with multiple SELECT statements by only ever exposing the data in the final SELECT statement as the data in the report.

This is now changed. Now if there are multiple SELECT statements in a report (that result in rows), they are all output:

- For the CSV output, all the rows from all the SELECTs are concatenated together
- For ODS output, each SELECT's rows are output in another sheet

While this is a technically a breaking change in the code, the instance of the Public Data API at https://data.api.trade.gov.uk/ doesn't as yet have any reports that have multiple SELECT statements, so until they do, this won't introduce any different behaviour.

The use case for this is the UK Tariff, usually accessed via https://www.data.gov.uk/dataset/3bee9a8a-e69c-400e-add5-3345a87a8e25/tariffs-to-trade-with-the-uk-from-1-january-2021. At the moment each of the 21 "Sections" of the tariff's "Measures on Declarable Commodities" report" is a separate report, which means to download the whole thing the user has to download 21 files which is not convenient. This change allows all 21 sections to be in a single file - it can have a single "report" with 21 SELECT statements in it. They are not all in the one ODS sheet, because this makes it not usable in Excel - all sections in one sheet go beyond Excel's limit on how many rows are in one sheet. When split into 21 sheets in a single ODS file, this makes it usable in Excel.

The single CSV file is most likely not openable in Excel, but given the ODS file should be, this is probably acceptable and a step forward because non-Excel CSV-users should be able to open the single file