### PR TITLE
feat: name ods report sheet by section

### DIFF
--- a/app_worker.py
+++ b/app_worker.py
@@ -278,7 +278,7 @@ def ensure_csvs(
                     with rollback(query):
                         s3_key = f'{dataset_id}/{version}/reports/{report_id}/data.ods'
                         sheets = (
-                            (name + (f' - {i+1}' if num_statements > 1 else ''), cols, rows)
+                            (f'Section {i+1}' if num_statements > 1 else name, cols, rows)
                             for i, (cols, rows) in enumerate(
                                 with_non_zero_rows(query_multi(script)))
                         )

--- a/test_app.py
+++ b/test_app.py
@@ -1731,10 +1731,11 @@ def test_csvs_and_ods_created_from_sqlite_with_reports(processes):
         with tempfile.NamedTemporaryFile() as f:
             f.write(response.content)
             f.flush()
-            report_1 = pd.read_excel(f.name, 'my_report - 1')
+
+            report_1 = pd.read_excel(f.name, 'Section 1')
             report_1_rows = report_1.values.tolist()
             report_1_cols = report_1.columns.tolist()
-            report_2 = pd.read_excel(f.name, 'my_report - 2')
+            report_2 = pd.read_excel(f.name, 'Section 2')
             report_2_rows = report_2.values.tolist()
             report_2_cols = report_2.columns.tolist()
 


### PR DESCRIPTION
We are changing the report sheet names to be labelled by section rather than the report name due to Excel's sheet name character limits