### PR TITLE
feat: move from ECS to ASIM logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import re
 from collections import namedtuple
 from itertools import chain
 
-import ecs_logging
 from gevent import (
     monkey,
 )
@@ -61,6 +60,9 @@ from app_aws import (
     aws_select_parse_result,
     aws_list_folders,
     aws_list_keys,
+)
+from app_logging import (
+    ASIMFormatter,
 )
 
 
@@ -1036,7 +1038,7 @@ def main():
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(ecs_logging.StdlibFormatter())
+    handler.setFormatter(ASIMFormatter())
     logger.addHandler(handler)
 
     start, stop = proxy_app(

--- a/app_logging.py
+++ b/app_logging.py
@@ -1,0 +1,46 @@
+import datetime
+import json
+import logging
+import os
+from flask import request, has_request_context
+
+
+class ASIMFormatter(logging.Formatter):
+    def format(self, record):
+        log_time = datetime.datetime.utcfromtimestamp(record.created).isoformat()
+        return json.dumps({
+            'EventMessage': record.getMessage(),
+            'EventCount': 1,
+            'EventStartTime': log_time,
+            'EventEndTime': log_time,
+            'EventType': record.name,
+            'EventResult': 'NA',
+            'EventSeverity': {
+                'DEBUG': 'Informational',
+                'INFO': 'Informational',
+                'WARNING': 'Low',
+                'ERROR': 'Medium',
+                'CRITICAL': 'High',
+            }[record.levelname],
+            'EventOriginalSeverity': record.levelname,
+            'EventSchema': 'ProcessEvent',
+            'EventSchemaVersion': '0.1.4',
+            'ActingAppType': 'Flask',
+            'AdditionalFields': {
+                # This _would_ be the version of the library making the log message, but we're
+                # using one built right into the Public Data API
+                'PublicDataAPIAsimVersion': os.environ.get('GIT_COMMIT'),
+                'TraceHeaders': {
+                    key: request.headers[key]
+                    for key in ('X-Amzn-Trace-Id', 'X-B3-TraceId', 'X-B3-SpanId')
+                    if key in request.headers
+                } if has_request_context() else {}
+            }
+        } | ({
+            'HttpUserAgent': request.headers.get('User-Agent'),
+            'SrcPortNumber': request.environ.get('REMOTE_PORT'),
+            'SrcIpAddr': request.remote_addr,
+            'IpAddr': request.remote_addr,
+            'SrcUserId': None,
+            'SrcUsername': 'AnonymousUser',
+        } if has_request_context() else {}))

--- a/app_worker.py
+++ b/app_worker.py
@@ -5,8 +5,6 @@ from gevent import (
 )
 monkey.patch_all()
 
-import ecs_logging
-
 from base64 import (
     b64encode,
 )
@@ -41,6 +39,9 @@ from app_aws import (
     aws_list_folders,
     aws_head,
     aws_multipart_upload,
+)
+from app_logging import (
+    ASIMFormatter,
 )
 
 
@@ -380,7 +381,7 @@ def main():
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(ecs_logging.StdlibFormatter())
+    handler.setFormatter(ASIMFormatter())
     logger.addHandler(handler)
 
     if os.environ.get('SENTRY_DSN'):

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-ecs-logging
 Flask
 gevent
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,6 @@ charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via flask
-ecs-logging==0.5.0
-    # via -r requirements.in
 elastic-apm[flask]==6.9.1
     # via -r requirements.in
 flask==2.3.2

--- a/test_app.py
+++ b/test_app.py
@@ -1754,7 +1754,7 @@ def test_csvs_and_ods_created_from_sqlite_with_reports(processes):
     ]
 
 
-def test_logs_ecs_format():
+def test_logs_asim_format():
     with application() as (_, outputs):
         dataset_id = str(uuid.uuid4())
         content = str(uuid.uuid4()).encode() * 100000
@@ -1773,7 +1773,7 @@ def test_logs_ecs_format():
     assert len(web_output_logs) >= 1
     web_api_call_log = [json.loads(log) for log in web_output_logs if url in log]
     assert len(web_api_call_log) == 2
-    assert 'ecs' in web_api_call_log[0]
+    assert 'EventMessage' in web_api_call_log[0]
     assert b'Shut down gracefully' in web_output
 
     worker_output, worker_error = outputs['worker']


### PR DESCRIPTION
To be ready for the move from GOV.UK PaaS to DBT Platform, we're changing the logging format from ECS to ASIM.

It's still JSON, but with different fields. Heavily inspired by  https://github.com/uktrade/django-log-formatter-asim