### PR TITLE
build(deps): bump pylint and pyyaml in dev requirements

### DIFF
--- a/app_aws.py
+++ b/app_aws.py
@@ -445,8 +445,7 @@ def aws_multipart_upload(
         with signed_s3_request('POST', key, params=(('uploads', ''),)) as response:
             response_body = response.read()
             if response.status != 200:
-                raise Exception('Unable to start upload {} {} {}'.format(
-                    key, response.status, response_body))
+                raise Exception(f'Unable to start upload {key} {response.status} {response_body}')
             return re.search(b'<UploadId>(.*)</UploadId>', response_body)[1].decode('utf-8')
 
     def upload(upload_id, part_number, part):
@@ -454,8 +453,7 @@ def aws_multipart_upload(
         with signed_s3_request('PUT', key, params=params, body=part) as response:
             response_body = response.read()
             if response.status != 200:
-                raise Exception('Unable to upload part {} {} {}'.format(
-                    upload_id, part_number, response_body))
+                raise Exception(f'Unable to upload part {upload_id} {part_number} {response_body}')
             return part_number, response.headers['etag']
 
     def complete(upload_id, part_numbers_etags):
@@ -469,8 +467,7 @@ def aws_multipart_upload(
         with signed_s3_request('POST', key, params=params, body=body) as response:
             response_body = response.read()
             if response.status != 200:
-                raise Exception('Upload to complete upload {} {} {}'.format(
-                    upload_id, key, response_body))
+                raise Exception(f'Upload to complete upload {upload_id} {key} {response_body}')
 
     # Upload in multiple threads so the iteration over incoming chunks is less likely to stall.
     # We also limit the ThreadPoolExecutor so we block iteration over incoming chunks so we don't

--- a/app_worker.py
+++ b/app_worker.py
@@ -370,8 +370,8 @@ def ensure_csvs(
         with signed_s3_request('PUT', s3_key=etag_key) as response:
             put_response_body = response.read()
             if response.status != 200:
-                raise Exception('Error saving etag object {} {} {}'.format(
-                    etag_key, response.status, put_response_body))
+                raise Exception(
+                    f'Error saving etag object {etag_key,} {response.status} {put_response_body}')
 
         logger.info('Saved as CSV %s %s', dataset_id, version)
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -129,12 +129,14 @@ pep517==0.12.0
 pip-tools==6.4.0
     # via -r requirements_test.in
 platformdirs==2.4.0
-    # via virtualenv
+    # via
+    #   pylint
+    #   virtualenv
 pluggy==0.13.1
     # via pytest
 pre-commit==2.15.0
     # via -r requirements_test.in
-pylint==2.3.1
+pylint==2.11.1
     # via -r requirements_test.in
 pyparsing==2.4.7
     # via packaging
@@ -144,7 +146,7 @@ python-dateutil==2.8.2
     # via pandas
 pytz==2021.3
     # via pandas
-pyyaml==5.4
+pyyaml==6.0.1
     # via pre-commit
 requests==2.31.0
     # via -r requirements.txt
@@ -179,13 +181,17 @@ stream-zip==0.0.46
 tidy-json-to-csv==0.0.13
     # via -r requirements.txt
 toml==0.10.0
-    # via pre-commit
+    # via
+    #   pre-commit
+    #   pylint
 tomli==1.2.2
     # via
     #   pep517
     #   pytest
 typing-extensions==4.8.0
-    # via astroid
+    # via
+    #   astroid
+    #   pylint
 urllib3==2.0.7
     # via
     #   -r requirements.txt

--- a/test_app.py
+++ b/test_app.py
@@ -42,7 +42,7 @@ def application(port=8080, max_attempts=500, aws_access_key_id='AKIAIOSFODNN7EXA
         </VersioningConfiguration>
     '''.encode(), params=(('versioning', ''),))
     delete_all_objects()
-    with open('Procfile', 'r') as file:
+    with open('Procfile', 'r', encoding='utf-8') as file:
         lines = file.read().splitlines()
 
     process_definitions = {


### PR DESCRIPTION
This increases the version of pylint, as a speculative change to see if it addresses linting failures of a separate PR:

> AttributeError: 'Attribute' object has no attribute 'value'

The version of pyyaml is bumped because the existing version has trouble building locally on my computer, raising:

> AttributeError: cython_sources

The changes in the code are to get it to pass pylint checks with its newer version.