### PR TITLE
feat: delete previous pingdom endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1026,7 +1026,6 @@ def proxy_app(
         '/v1/datasets/<string:dataset_id>/versions/<string:version>/metadata',
         view_func=proxy_metadata,
     )
-    app.add_url_rule('/healthcheck', 'healthcheck', view_func=healthcheck)
     app.add_url_rule('/pingdom/ping.xml', 'healthcheck', view_func=healthcheck)
     app.add_url_rule('/', 'docs', view_func=docs)
     app.add_url_rule('/accessibility_statement', view_func=accessibility_statement)

--- a/test_app.py
+++ b/test_app.py
@@ -1823,7 +1823,7 @@ def test_healthcheck_ok(processes):
 
     with \
             requests.Session() as session, \
-            session.get('http://127.0.0.1:8080/healthcheck') as response:
+            session.get('http://127.0.0.1:8080/pingdom/ping.xml') as response:
         assert response.status_code == 200
         assert '<status>OK</status>' in str(response.content)
         assert response.headers['content-type'] == 'text/xml'
@@ -1839,7 +1839,7 @@ def test_healthcheck_fail(processes):
 
     with \
             requests.Session() as session, \
-            session.get('http://127.0.0.1:8080/healthcheck') as response:
+            session.get('http://127.0.0.1:8080/pingdom/ping.xml') as response:
         assert response.status_code == 503
 
 


### PR DESCRIPTION
We are switching to using /pingdom/ping.xml instead of /healthcheck, have reconfigured in pingdom to reflect this so this rule can be removed.