### PR TITLE
feat: basic CLI to check heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ If the AWS user has the ListBucket permission, 404s are proxied through to the u
 ## Shutdown
 
 On SIGTERM any in-progress requests will complete before the process exits. At the time of writing PaaS will then forcibly kill the process with SIGKILL if it has not exited within 10 seconds.
+
+
+## Worker health
+
+A basic CLI is included to check the health of the backend worker that converts between data formats.
+
+```bash
+python -m app_heartbeat
+```
+
+A zero exit codes means the worker is healthy, otherwise the worker is not healthy.

--- a/app_heartbeat.py
+++ b/app_heartbeat.py
@@ -1,0 +1,19 @@
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+
+HEARTBEAT_FILE = Path(f'{tempfile.gettempdir()}/public_data_api_worker_heartbeat')
+
+
+def heartbeat(logger, shut_down_heartbeat, thread):
+    while True:
+        if shut_down_heartbeat.wait(timeout=1.0):
+            break
+
+        if thread.is_alive():
+            HEARTBEAT_FILE.write_text(str(datetime.now().timestamp()), encoding='utf-8')
+        else:
+            logger.info('Heartbeat: is not alive')
+
+    HEARTBEAT_FILE.unlink(missing_ok=True)

--- a/app_heartbeat.py
+++ b/app_heartbeat.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -17,3 +18,16 @@ def heartbeat(logger, shut_down_heartbeat, thread):
             logger.info('Heartbeat: is not alive')
 
     HEARTBEAT_FILE.unlink(missing_ok=True)
+
+
+def check_heartbeat():
+    now = datetime.now().timestamp()
+
+    exists = HEARTBEAT_FILE.exists()
+    recent = exists and (now - float(HEARTBEAT_FILE.read_text(encoding='utf-8'))) < 60
+    exit_code = 0 if recent else 1
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    check_heartbeat()

--- a/app_worker.py
+++ b/app_worker.py
@@ -20,10 +20,8 @@ import logging
 import os
 import signal
 import sys
-import tempfile
 import threading
 import urllib.parse
-from pathlib import Path
 
 import sentry_sdk
 from tidy_json_to_csv import (
@@ -42,12 +40,12 @@ from app_aws import (
     aws_head,
     aws_multipart_upload,
 )
+from app_heartbeat import (
+    heartbeat,
+)
 from app_logging import (
     ASIMFormatter,
 )
-
-
-HEARTBEAT_FILE = Path(f'{tempfile.gettempdir()}/public_data_api_worker_heartbeat')
 
 
 def ensure_csvs(
@@ -426,24 +424,16 @@ def main():
     def stop(_, __):
         shut_down.set()
 
-    def heartbeat(thread):
-        while True:
-            if shut_down_heartbeat.wait(timeout=1.0):
-                break
-
-            if thread.is_alive():
-                HEARTBEAT_FILE.write_text(str(datetime.now().timestamp()), encoding='utf-8')
-            else:
-                logger.info('Heartbeat: is not alive')
-
-        HEARTBEAT_FILE.unlink(missing_ok=True)
-
     signal.signal(signal.SIGTERM, stop)
     thread = threading.Thread(target=run)
     thread.start()
 
     logger.info('Starting heartbeat')
-    heartbeat_thread = threading.Thread(target=heartbeat, kwargs=dict(thread=thread))
+    heartbeat_thread = threading.Thread(target=heartbeat, kwargs=dict(
+        logger=logger,
+        shut_down_heartbeat=shut_down_heartbeat,
+        thread=thread,
+    ))
     heartbeat_thread.start()
 
     thread.join()

--- a/test_app.py
+++ b/test_app.py
@@ -1798,6 +1798,20 @@ def test_heartbeat():
     assert not hearbeat_file.exists()
 
 
+def test_check_heartbeat():
+    result = subprocess.run(['python', '-m', 'app_heartbeat'], check=False)
+    assert result.returncode == 1
+
+    with application():
+        time.sleep(2)
+
+        result = subprocess.run(['python', '-m', 'app_heartbeat'], check=False)
+        assert result.returncode == 0
+
+    result = subprocess.run(['python', '-m', 'app_heartbeat'], check=False)
+    assert result.returncode == 1
+
+
 def test_elastic_apm(processes):
     dataset_id = str(uuid.uuid4())
     content = str(uuid.uuid4()).encode() * 100000


### PR DESCRIPTION
This adds a basic CLI to check the heartbeat file.

This isn't used now, but will be used when we move to DBT Platform, that uses file-based heartbeats for backend workers.