### PR TITLE
build(deps): bump sqlite-s3-query and remove explicit transactions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-sqlite-s3-query==0.0.67
+sqlite-s3-query==0.0.68
     # via -r requirements.in
 stream-write-ods==0.0.24
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -162,7 +162,7 @@ sniffio==1.3.1
     #   -r requirements.txt
     #   anyio
     #   httpx
-sqlite-s3-query==0.0.67
+sqlite-s3-query==0.0.68
     # via -r requirements.txt
 stream-write-ods==0.0.24
     # via -r requirements.txt


### PR DESCRIPTION
sqlite-s3-query 0.0.68 creates a new connection for every call to the `query` function. As a result, transactions do not persist between one call to the `query` function and the next, therefore it's incorrect to pass it 'ROLLBACK', because there is now never a transaction in progress: calling ROLLBACK causes a SQLite Logic Error.

In addition, the isolation provided by the transactions prior to this change is now given by the separate connections, so there isn't a need for transactions at all. So, we can and do remove them.

Note that for each new `query` function that's generated by sqlite-s3-query, even over multiple calls to it, it will always query the same version of the sqlite file in the s3 bucket. And so even if the sqlite file is replaced between multiple calls to `query`, this change doesn't introduce inconsistency issues.