### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @uktrade/data-infrastructure


### PR DESCRIPTION
This adds a CODEOWNERS to automatically invite the data-infrastructure team to code reviews (and just make it a touch clearer who is responsible for this repository)