### PR TITLE
ci: use OIDC for code coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # For OIDC code coverage upload
+    permissions:
+      id-token: write
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
@@ -29,4 +32,6 @@ jobs:
       - name: "Test"
         run: |
           ./test_app.sh
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        with:
+          use_oidc: true


### PR DESCRIPTION
Code Coverage doesn't seem to be showing at
https://app.codecov.io/gh/uktrade/public-data-api. Trying to explicitly use OIDC to see if that sorts it.