### PR TITLE
ci: try moving back to v3 for Code Coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    # For OIDC code coverage upload
-    permissions:
-      id-token: write
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
@@ -32,6 +29,4 @@ jobs:
       - name: "Test"
         run: |
           ./test_app.sh
-      - uses: codecov/codecov-action@v4
-        with:
-          use_oidc: true
+      - uses: codecov/codecov-action@v3


### PR DESCRIPTION
On V4 with OIDC it's still not working for some reason (either timeout or authentication errors when uploading)