### PR TITLE
ci: use token rather than OIDC for Codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    # For OIDC code coverage upload
-    permissions:
-      id-token: write
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
@@ -34,4 +31,4 @@ jobs:
           ./test_app.sh
       - uses: codecov/codecov-action@v4
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
No matter what, with OIDC it seems to fail with the message:

> Upload failed: {"detail":"Failed token authentication, please double-check that
> your repository token matches in the Codecov UI, or review the docs