### PR TITLE
build(deps): upgrade sentry-sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ pycryptodome==3.20.0
     # via stream-zip
 requests==2.32.0
     # via -r requirements.in
-sentry-sdk[flask]==2.0.1
+sentry-sdk[flask]==2.10.0
     # via -r requirements.in
 sniffio==1.3.1
     # via

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -147,7 +147,7 @@ pyyaml==6.0.1
     # via pre-commit
 requests==2.32.0
     # via -r requirements.txt
-sentry-sdk[flask]==2.0.1
+sentry-sdk[flask]==2.10.0
     # via
     #   -r requirements.txt
     #   -r requirements_test.in


### PR DESCRIPTION
This is to address https://github.com/advisories/GHSA-g92j-qhmh-64v2