### PR TITLE
feat: generate data.json metadata file from backend worker

### DIFF
--- a/test_app.py
+++ b/test_app.py
@@ -68,6 +68,7 @@ def application(port=8080, max_attempts=500, aws_access_key_id='AKIAIOSFODNN7EXA
             env={
                 **os.environ,
                 'PORT': str(port),
+                'DOCS_BASE_URL': 'http://127.0.0.1:8080',
                 'AWS_S3_REGION': 'us-east-1',
                 'READONLY_AWS_ACCESS_KEY_ID': aws_access_key_id,
                 'READONLY_AWS_SECRET_ACCESS_KEY': (
@@ -406,14 +407,16 @@ def test_metadata_key_that_exists(processes):
                 b'header\n' + b'value\n' * 20000)
     put_version('report', dataset_id, version, 'the-second-report',
                 b'header\n' + b'value\n' * 2000000)
-    put_version_data(dataset_id, version, b'value\n' * 500, 'sqlite')
+    put_version_data(dataset_id, version, get_sqlite_data(), 'sqlite')
     put_version_metadata(dataset_id, version, content)
 
     with \
             requests.Session() as session, \
             session.get(version_metadata_public_html_url(dataset_id, version)) as response:
         assert b'The updated title of the dataset - v0.0.2' in response.content
-        assert b'(SQLite, 3.0 kB)' in response.content
+        assert b'(SQLite, 3.6 MB)' in response.content
+
+    time.sleep(36)
 
     with \
             requests.Session() as session, \


### PR DESCRIPTION
This is because it was taking too long to do in the request response cycle, but also it was returning versions that appeared ready even though the backend worker had not completed processing them.