### PR TITLE
build(deps): update to stream-write-ods v0.0.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ sniffio==1.3.1
     #   httpx
 sqlite-s3-query==0.0.81
     # via -r requirements.in
-stream-write-ods==0.0.24
+stream-write-ods==0.0.25
     # via -r requirements.in
 stream-zip==0.0.71
     # via stream-write-ods

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -160,7 +160,7 @@ sniffio==1.3.1
     #   httpx
 sqlite-s3-query==0.0.81
     # via -r requirements.txt
-stream-write-ods==0.0.24
+stream-write-ods==0.0.25
     # via -r requirements.txt
 stream-zip==0.0.71
     # via


### PR DESCRIPTION
Update to the new version stream-write-ods that has optional use of Zip64.