### PR TITLE
Add port 9001 to container for Minio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DOCS_SERVICE_NAME='Data API' \
 DOCS_GITHUB_REPO_URL=https://github.com/uktrade/public-data-api \
     python3 -m app
 ```
+The S3-compatible storage on your local machine will be visible at http://localhost:9001/. The username and password for the console login are the environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY from ./start-services.sh.
+
 
 
 ## Environment variables

--- a/mock_sentry_app.py
+++ b/mock_sentry_app.py
@@ -43,7 +43,7 @@ def sentry_app():
         '/api/1/errors/', methods=['GET'], view_func=_errors
     )
 
-    server = WSGIServer(('0.0.0.0', 9001), app)
+    server = WSGIServer(('0.0.0.0', 9003), app)
 
     return start, stop
 

--- a/start-services.sh
+++ b/start-services.sh
@@ -4,10 +4,10 @@ set -e
 
 docker network create public-data-api-network --driver=bridge
 
-docker run --rm -p 9000:9000 --name s3proxy-minio -d \
-  -e 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE' \
-  -e 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
-  -e 'MINIO_REGION=us-east-1' \
-  --entrypoint sh \
-  minio/minio:RELEASE.2021-11-24T23-19-33Z.hotfix.1d85a4563 \
-  -c 'mkdir -p /data1 && mkdir -p /data2 && mkdir -p /data3 && mkdir -p /data4 && minio server /data{1...4}'
+docker run --rm -p 9000:9000 -p 9001:9001 --name s3proxy-minio -d \
+-e 'MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE' \
+-e 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
+-e 'MINIO_REGION=us-east-1' \
+--entrypoint sh \
+minio/minio:RELEASE.2021-11-24T23-19-33Z.hotfix.1d85a4563 \
+-c 'mkdir -p /data1 && mkdir -p /data2 && mkdir -p /data3 && mkdir -p /data4 && minio server /data{1...4} --console-address :9001'

--- a/test_app.py
+++ b/test_app.py
@@ -80,7 +80,7 @@ def application(port=8080, max_attempts=500, aws_access_key_id='AKIAIOSFODNN7EXA
                 ),
                 'AWS_S3_ENDPOINT': 'http://127.0.0.1:9000/my-bucket/',
                 'ENVIRONMENT': 'test',
-                'SENTRY_DSN': 'http://foo@localhost:9001/1',
+                'SENTRY_DSN': 'http://foo@localhost:9003/1',
                 'GA_ENDPOINT': 'http://localhost:9002/collect',
                 'GA_TRACKING_ID': 'XX-XXXXX-X',
             }
@@ -1897,7 +1897,7 @@ def test_sentry_integration(processes_bad_key):
 
     with \
             requests.Session() as session, \
-            session.get('http://127.0.0.1:9001/api/1/errors') as response:
+            session.get('http://127.0.0.1:9003/api/1/errors') as response:
         assert int(response.content) >= 10
 
 


### PR DESCRIPTION
Added secondary port (9001) to the container that runs the Minio server, such that the Minio console can be viewed in a browser (for local development purposes)

Tested locally by executing start-services.sh and I could see the console on http://localhost:9001

Sorry that the changes were made in one new big block of 'docker run' command rather than just changing the bits that need changing. Hopefully it's clear enough the two bits that I changed i.e. adding '-p 9001:9001' and '--console-address :9001' to the 'docker run' options' list