### PR TITLE
feat: convert tables and reports to Parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The S3-compatible storage on your local machine will be visible at http://localh
 | READ_AND_WRITE_AWS_ACCESS_KEY_ID     | The AWS access key ID that has write permissions on the S3 bucket (for the csv-generating worker) |
 | READ_AND_WRITE_AWS_SECRET_ACCESS_KEY | The secret part of the read+write AWS access key |
 | ENVIRONMENT           | The current environment where the application is running<hr>`develop` |
+| PARQUET_ROW_GROUP_SIZE | The maximum number of rows Parquet row group - optional with a default of 1131072 |
 | GA_ENDPOINT (deprecated)          | The endpoint to send analytics info to |
 | GA_TRACKING_ID (deprecated)       | The unique identifier for the google analytics property |
 | GA4_API_SECRET        | The API secret for Google Analytics 4 (GA4) |

--- a/app.py
+++ b/app.py
@@ -564,6 +564,7 @@ def proxy_app(
         (
             'csv',
             'ods',
+            'parquet',
         )
     )
     def proxy_table(dataset_id, version, table):
@@ -577,6 +578,7 @@ def proxy_app(
         (
             'csv',
             'ods',
+            'parquet',
         )
     )
     def proxy_report(dataset_id, version, table):
@@ -671,6 +673,8 @@ def proxy_app(
         content_type = (
             'text/csv'
             if _format == 'csv'
+            else 'application/vnd.apache.parquet'
+            if _format == 'parquet'
             else 'application/vnd.oasis.opendocument.spreadsheet'
         )
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,7 @@
 Flask
 gevent
+pandas
+pyarrow
 urllib3
 sentry-sdk[flask]
 tidy-json-to-csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,12 +50,24 @@ markupsafe==2.1.5
     #   jinja2
     #   sentry-sdk
     #   werkzeug
+numpy==1.26.4
+    # via pandas
+pandas==2.2.3
+    # via -r requirements.in
+pyarrow==18.0.0
+    # via -r requirements.in
 pycryptodome==3.20.0
     # via stream-zip
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2024.2
+    # via pandas
 requests==2.32.0
     # via -r requirements.in
 sentry-sdk[flask]==2.10.0
     # via -r requirements.in
+six==1.16.0
+    # via python-dateutil
 sniffio==1.3.1
     # via
     #   anyio
@@ -68,6 +80,8 @@ stream-zip==0.0.71
     # via stream-write-ods
 tidy-json-to-csv==0.0.13
     # via -r requirements.in
+tzdata==2024.2
+    # via pandas
 urllib3==2.2.2
     # via
     #   -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -108,15 +108,19 @@ mccabe==0.7.0
 nodeenv==1.8.0
     # via pre-commit
 numpy==1.26.4
-    # via pandas
+    # via
+    #   -r requirements.txt
+    #   pandas
 odfpy==1.4.1
     # via -r requirements_test.in
 packaging==24.0
     # via
     #   build
     #   pytest
-pandas==2.2.2
-    # via -r requirements_test.in
+pandas==2.2.3
+    # via
+    #   -r requirements.txt
+    #   -r requirements_test.in
 pip-tools==7.4.1
     # via -r requirements_test.in
 platformdirs==4.2.1
@@ -127,6 +131,8 @@ pluggy==1.5.0
     # via pytest
 pre-commit==3.7.0
     # via -r requirements_test.in
+pyarrow==18.0.0
+    # via -r requirements.txt
 pycryptodome==3.20.0
     # via
     #   -r requirements.txt
@@ -140,9 +146,13 @@ pyproject-hooks==1.1.0
 pytest==8.2.0
     # via -r requirements_test.in
 python-dateutil==2.9.0.post0
-    # via pandas
-pytz==2024.1
-    # via pandas
+    # via
+    #   -r requirements.txt
+    #   pandas
+pytz==2024.2
+    # via
+    #   -r requirements.txt
+    #   pandas
 pyyaml==6.0.1
     # via pre-commit
 requests==2.32.0
@@ -152,7 +162,9 @@ sentry-sdk[flask]==2.10.0
     #   -r requirements.txt
     #   -r requirements_test.in
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   -r requirements.txt
+    #   python-dateutil
 sniffio==1.3.1
     # via
     #   -r requirements.txt
@@ -170,8 +182,10 @@ tidy-json-to-csv==0.0.13
     # via -r requirements.txt
 tomlkit==0.12.4
     # via pylint
-tzdata==2024.1
-    # via pandas
+tzdata==2024.2
+    # via
+    #   -r requirements.txt
+    #   pandas
 urllib3==2.2.2
     # via
     #   -r requirements.txt

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -132,7 +132,7 @@
               <li>Each dataset version has zero or more reports - a report contains filtered or aggregated table data</li>
               <li>Metadata for each dataset version is available as <a href="https://en.wikipedia.org/wiki/HTML">HTML</a> or <a href="https://www.w3.org/TR/tabular-data-primer/">CSVW</a> (CSV on the Web)</li>
               <li>Data can be filtered or aggregated using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference-select.html">S3 Select query language</a></li>
-              <li>Data is supplied as <a href="https://www.sqlite.org/">SQLite</a>, <a href="https://en.wikipedia.org/wiki/JSON">JSON</a>, <a href="https://www.gov.uk/government/publications/recommended-open-standards-for-government/tabular-data-standard">CSV</a>, or <a href="https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation">ODS (OpenDocument Spreadsheet)</a>.</li>
+              <li>Data is supplied as <a href="https://www.sqlite.org/">SQLite</a>, <a href="https://en.wikipedia.org/wiki/JSON">JSON</a>, <a href="https://www.gov.uk/government/publications/recommended-open-standards-for-government/tabular-data-standard">CSV</a>, <a href="https://parquet.apache.org/">Apache Parquet</a>, or <a href="https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation">ODS (OpenDocument Spreadsheet)</a>.</li>
             </ul>
 
             <p>The source code for the {{ service_name }} is available in its <a href="{{ github_repo_url }}">GitHub repository</a>.</p>
@@ -471,7 +471,7 @@
                 <tr class="govuk-table__row">
                   <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code></td>
                   <td class="govuk-table__cell">Yes</td>
-                  <td class="govuk-table__cell">The requested output format. This must be <code class="hljs html">csv</code> or <code class="hljs html">ods</code></td>
+                  <td class="govuk-table__cell">The requested output format. This must be <code class="hljs html">csv</code>, <code class="hljs html">ods</code>, or <code class="hljs html">parquet</code></td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">query-s3-select</code></td>
@@ -564,7 +564,7 @@ commodity__code,commodity__suffix,commodity__description
                 <tr class="govuk-table__row">
                   <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">format</code></td>
                   <td class="govuk-table__cell">Yes</td>
-                  <td class="govuk-table__cell">The requested output format. This must be <code class="hljs html">csv</code> or <code class="hljs html">ods</code></td>
+                  <td class="govuk-table__cell">The requested output format. This must be <code class="hljs html">csv</code>, <code class="hljs html">ods</code>, or <code class="hljs html">parquet</code></td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td scope="row" class="govuk-table__cell"><code class="hljs html nowrap">query-s3-select</code></td>


### PR DESCRIPTION
This adds Apache Parquet to the output format list. This is done for 2 reasons:

- Apache Parquet is more and more the format used to transfer big datasets. Although our datasets are so far not really "big", the format is nevertheless fairly expected these days and users are often setup to ingest it
- To slowly increase our organisational knowledge of Parquet

The tweaks to testing that fires up processes, especially the addition of the sleep, is to make sure to catch stdout output, which for some reason takes longer with this change.
