### PR TITLE
fix: march forward with conversion if cannot convert to Parquet

### DIFF
--- a/app_worker.py
+++ b/app_worker.py
@@ -272,8 +272,11 @@ def ensure_csvs(
                     s3_key = f'{dataset_id}/{version}/tables/{table_id}/data.parquet'
                     logger.info('Converting %s %s SQLite table %s to Parquet in %s', dataset_id,
                                 version, table_name, s3_key)
-                    aws_multipart_upload(signed_s3_request, s3_key,
-                                         stream_write_parquet(cols, rows))
+                    try:
+                        aws_multipart_upload(signed_s3_request, s3_key,
+                                             stream_write_parquet(cols, rows))
+                    except pa.ArrowNotImplementedError:
+                        logger.exception('Unable to convert to parquet')
 
                 # And save as a single ODS file
                 s3_key = f'{dataset_id}/{version}/tables/{table_id}/data.ods'
@@ -347,8 +350,11 @@ def ensure_csvs(
                     for (_, rows_in_query) in all_cols_rows
                     for row in rows_in_query
                 ))
-                aws_multipart_upload(signed_s3_request, s3_key,
-                                     stream_write_parquet(cols, rows))
+                try:
+                    aws_multipart_upload(signed_s3_request, s3_key,
+                                         stream_write_parquet(cols, rows))
+                except pa.ArrowNotImplementedError:
+                    logger.exception('Unable to convert to parquet')
 
                 # ... and as ODS with the results of each statement as a separate sheet
                 s3_key = f'{dataset_id}/{version}/reports/{report_id}/data.ods'


### PR DESCRIPTION
This change wraps the code that converts to Parquet format with a try block to march forward in the case of ArrowNotImplementedError. This is to work around the error:

> ArrowNotImplementedError ("NumPyConverter doesn't implement <null> conversion."
> , 'Conversion failed for column <column_name> with type float64')

(The "<column_name>" in the real error has the name of the column).

That I suspect is due to Pandas schema detection assuming a column only has null in because it only null appears at the beginning, but then non-null values appear later.

This is causing a fair bit of noise in logs. Since we only introduced Parquet recently, for now I think this is the best option because it's not taking Parquet away from any files that already have it.