### PR TITLE
fix: carry on in the face of more arrow-exceptions

### DIFF
--- a/app_worker.py
+++ b/app_worker.py
@@ -275,7 +275,7 @@ def ensure_csvs(
                     try:
                         aws_multipart_upload(signed_s3_request, s3_key,
                                              stream_write_parquet(cols, rows))
-                    except (pa.ArrowNotImplementedError, pa.ArrowTypeError):
+                    except pa.ArrowException:
                         logger.exception('Unable to convert to parquet')
 
                 # And save as a single ODS file


### PR DESCRIPTION
There are more Parquet-related exceptions that prevent the file format conversion from progressing.

Instead of continuing to add to the list of exception types, have found the PyArrow exception base class at
https://github.com/apache/arrow/blob/fb8e8122f623f4548b22ece7485c4570d7ece1a6/python/pyarrow/error.pxi#L33C7-L33C21

(This is vey similary to previous fixes)