### PR TITLE
refactor: remove unnecessary nonlocal to fix linting

### DIFF
--- a/mock_google_analytics_app.py
+++ b/mock_google_analytics_app.py
@@ -29,7 +29,6 @@ def google_analytics_app():
         server.stop()
 
     def _store():
-        nonlocal calls
         calls.append(request.form)
         return 'OK'
 


### PR DESCRIPTION
This removes an unnecessary nonlocal variable in the mock GA server. While it doesn't change behaviour, it addresses a linting error.